### PR TITLE
Adjust to rely upon Services API to determine service state

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/canonical/operator@3d5170ee2c490bf96642d9f011424ff9a4eb187c#egg=ops
+git+git://github.com/canonical/operator@57b4f5259b93b320d7f412798dd22a58b031c14f#egg=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,10 +7,9 @@
 import logging
 
 from ops.charm import CharmBase
-from ops.main import main
 from ops.framework import StoredState
+from ops.main import main
 from ops.model import ActiveStatus
-
 
 logger = logging.getLogger(__name__)
 
@@ -31,19 +30,22 @@ class SnappassTestCharm(CharmBase):
         )
 
     def _on_snappass_pebble_ready(self, event):
-        logger.info('_on_snappass_pebble_ready')
+        logger.info("_on_snappass_pebble_ready")
         self._stored.snappass_pebble_ready = True
         if self._stored.redis_started:
             # Redis started first, start snappass server now
             self._start_snappass()
 
     def _start_snappass(self):
-        logger.info('_start_snappass')
+        logger.info("_start_snappass")
         if self._stored.snappass_started:
-            logger.info('snappass already started')
+            logger.info("snappass already started")
             return
-        container = self.unit.containers['snappass']
-        container.add_layer('snappass', """
+        container = self.unit.containers["snappass"]
+
+        container.add_layer(
+            "snappass",
+            """
 summary: snappass layer
 description: snappass layer
 services:
@@ -52,15 +54,19 @@ services:
         summary: snappass service
         command: snappass
         default: start
-""")
+""",
+            True,
+        )
         container.autostart()
-        self.unit.status = ActiveStatus('snappass started')
+        self.unit.status = ActiveStatus("snappass started")
         self._stored.snappass_started = True
 
     def _on_redis_pebble_ready(self, event):
-        logger.info('_on_redis_pebble_ready')
+        logger.info("_on_redis_pebble_ready")
         container = event.workload
-        container.add_layer('redis', """
+        container.add_layer(
+            "redis",
+            """
 summary: redis layer
 description: redis layer
 services:
@@ -69,9 +75,11 @@ services:
         summary: redis service
         command: redis-server
         default: start
-""")
+""",
+            True,
+        )
         container.autostart()
-        self.unit.status = ActiveStatus('redis started')
+        self.unit.status = ActiveStatus("redis started")
         self._stored.redis_started = True
 
         if self._stored.snappass_pebble_ready:


### PR DESCRIPTION
Hi

I was experimenting with the Services API today, and this is where I started - feel free to decline this PR! It's more in case you're interested...

Essentially, this stops using the stored state to track which services are up and running and relies upon the services API instead. I read somewhere that using stored state to track started/stop events in charms is a "bad smell"...

Other small changes
- Override the layers with `combine=True` - debug-log was getting spammed before without this
- Pass layer configs as dicts